### PR TITLE
Add Haxe support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "regex",
     "displayName": "Regex Previewer",
-    "description": "Regex matches previewer for JavaScript and TypeScript in Visual Studio Code.",
+    "description": "Regex matches previewer for JavaScript, TypeScript and Haxe in Visual Studio Code.",
     "version": "0.0.7",
     "publisher": "chrmarti",
     "repository": {
@@ -22,6 +22,7 @@
     "activationEvents": [
         "onLanguage:javascript",
         "onLanguage:typescript",
+        "onLanguage:haxe",
         "onCommand:extension.toggleRegexPreview"
     ],
     "main": "./out/src/extension",


### PR DESCRIPTION
Very cool extension!

[Regex literals in Haxe](https://haxe.org/manual/std-regex.html) are _very_ similar to those in TS / JS, so it was relatively simple to add support for them. The biggest difference is that they start with `~` (`~/regex/flags` instead of `/regex/flags`).

There are two other changes I made to the regexRegex:

- changed the flags to the ones accepted by Haxe
- accept a trailing dot for cases like this:

![](http://i.imgur.com/oCcDDmv.png)

Seems to work quite well so far, here it is in action:

![](http://i.imgur.com/ij7MS6c.gif)

If you want to test it, the [vshaxe codebase](https://github.com/vshaxe/vshaxe) is a good test bed (quite a few regex literals) - just search for `~/` with find in files.