### PR TITLE
added a check for comments inside JSX

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,9 @@ declare function clearInterval(token: IntervalToken): void;
 
 export function activate(context: vscode.ExtensionContext) {
 
+    // lines that start with {/* or end with */} are comments in JSX
+    const isJSXCommentRegex = /(^\s*{\/\*)|(\*\/}$)/;
+
     const regexRegex = /(^|\s|[()={},:?;])(\/((?:\\\/|\[[^\]]*\]|[^/])+)\/([gimuy]*))(\s|[()={},:?;]|$)/g;
     const phpRegexRegex = /(^|\s|[()={},:?;])['|"](\/((?:\\\/|\[[^\]]*\]|[^/])+)\/([gimuy]*))['|"](\s|[()={},:?;]|$)/g;
     const haxeRegexRegex = /(^|\s|[()={},:?;])(~\/((?:\\\/|\[[^\]]*\]|[^/])+)\/([gimsu]*))(\s|[.()={},:?;]|$)/g;
@@ -277,6 +280,9 @@ https://github.com/chrmarti/vscode-regex
             let regex = getRegexRegex(document.languageId);
             regex.lastIndex = 0;
             const text = line.text.substr(0, 1000);
+            if (isJSXComment(text)) {
+                continue;
+            }
             while ((match = regex.exec(text))) {
                 const result = createRegexMatch(document, i, match);
                 if (result) {
@@ -330,5 +336,10 @@ https://github.com/chrmarti/vscode-regex
             }
         }
         return matches;
+    }
+
+    function isJSXComment(line: string) {
+        // TODO - something to check settings if we want to support checking for JSX comments
+        return isJSXCommentRegex.exec(line) !== null;
     }
 }


### PR DESCRIPTION
The extension was "detecting" regular expressions inside of JSX comments (React code). I added a check to ignore these. You can see the problem that is fixed in the screenshot below. 

![image](https://user-images.githubusercontent.com/1342367/128245679-2be5d83f-a29e-41af-9fe6-742f4af6e863.png)

I've never made a VS Code extension before so there is probably a lot of room for improvement here. Maybe adding something to settings to toggle this feature, or having this only happen inside `.jsx` and `.tsx` files.